### PR TITLE
Update README to simplify the usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ plugins {
 
 repositories {
     maven {
-        url = uri("https://repo.gradle.org/gradle/ext-releases-local")
-        // `url "https://repo.gradle.org/gradle/ext-releases-local"` will do for Groovy scripts
+        url = uri("https://repo.gradle.org/gradle/libs")
+        // `url "https://repo.gradle.org/gradle/libs"` will do for Groovy scripts
     }
 }
 


### PR DESCRIPTION
Update README to suggest the library be used from the `libs` virtual repository at repo.gradle.org, rather than a specific release repository. This way, the tooling API and other dependencies which do not live in the specific repo are also found.