### PR TITLE
Change maven url to /libs instead of /ext-release-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ plugins {
 
 repositories {
     maven {
-        url = uri("https://repo.gradle.org/gradle/ext-releases-local")
-        // `url "https://repo.gradle.org/gradle/ext-releases-local"` will do for Groovy scripts
+        url = uri("https://repo.gradle.org/gradle/libs")
+        // `url "https://repo.gradle.org/gradle/libs"` will do for Groovy scripts
     }
 }
 


### PR DESCRIPTION
The tooling api is not available through ext-release-local, but is available through libs.