### PR TITLE
Fix reference to renamed method in error message

### DIFF
--- a/sample-check/src/main/java/org/gradle/samples/test/rule/Sample.java
+++ b/sample-check/src/main/java/org/gradle/samples/test/rule/Sample.java
@@ -97,8 +97,8 @@ public class Sample implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                assertNotNull("No sample selected. Please use @UsesSample or withDefaultSampleName()", sampleName);
-                assertNotNull("targetBaseDirSupplier must not be null. Please use into() to set one.", targetBaseDirSupplier);
+                assertNotNull("No sample selected. Please use @UsesSample or withDefaultSample()", sampleName);
+                assertNotNull("TargetBaseDirSupplier must not be null. Please use into() to set one.", targetBaseDirSupplier);
                 File srcDir = sourceSampleDirSupplier.getDir(sampleName);
                 FileUtils.copyDirectory(srcDir, getDir());
                 base.evaluate();


### PR DESCRIPTION
The error message was still referring to `withDefaultSampleName()` which
was renamed to `withDefaultSample()`.