### PR TITLE
Replace testRuntime with testRuntimeOnly

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -142,7 +142,7 @@ This library provides 2 JUnit runners link:src/main/java/org/gradle/samples/test
 ----
 dependencies {
     testImplementation(gradleTestKit())
-    testRuntime("org.slf4j:slf4j-simple:1.7.16")
+    testRuntimeOnly("org.slf4j:slf4j-simple:1.7.16")
 }
 ----
 


### PR DESCRIPTION
`testRuntime` is deprecated:
![bildschirmfoto 2018-10-12 um 11 22 13](https://user-images.githubusercontent.com/10229883/46860617-1660ab00-ce11-11e8-9bd2-e232b04cb6fb.png)
