### PR TITLE
Add special handling for `cd <x>` commands in samples

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -5,10 +5,11 @@ object Versions {
     val JUNIT = "4.12"
     val JSR305 = "3.0.2"
     val SLF4J = "1.7.16"
-    val SPOCK_CORE = "1.1-groovy-2.4"
+    val SPOCK_CORE = "1.2-groovy-2.5"
     val TYPESAFE_CONFIG = "1.2.1"
     val CGLIB = "3.2.7"
     val OBJENESIS = "2.6"
+    val GROOVY = "2.5.4"
 }
 
 object Libraries {
@@ -23,4 +24,5 @@ object Libraries {
     val TYPESAFE_CONFIG = "com.typesafe:config:${Versions.TYPESAFE_CONFIG}"
     val CGLIB = "cglib:cglib-nodep:${Versions.CGLIB}"
     val OBJENESIS = "org.objenesis:objenesis:${Versions.OBJENESIS}"
+    val GROOVY = "org.codehaus.groovy:groovy:${Versions.GROOVY}"
 }

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -90,6 +90,8 @@ commands: [{
 }]
 ----
 
+When there are multiple steps specified for a sample, they are run one after the other, in the order specified. The 'executable' can be either a command on the `$PATH`, or `gradle` (to run Gradle), or `cd` (to change the working directory for subsequent steps).
+
 _See <<sample-conf-fields,Sample Conf fields>> for a detailed description of all the possible options._
 
 *NOTE:* There are a bunch of (tested) samples under `sample-check/src/test/samples` of this repository you can use to understand ways to configure samples.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample-check/build.gradle.kts
+++ b/sample-check/build.gradle.kts
@@ -3,9 +3,6 @@ plugins {
 }
 
 dependencies {
-    constraints {
-        testImplementation("org.codehaus.groovy:groovy-all:2.4.15")
-    }
     api(project(":sample-discovery"))
     api(Libraries.JUNIT)
     compileOnly(Libraries.JSR305)
@@ -15,6 +12,7 @@ dependencies {
     testImplementation(Libraries.SPOCK_CORE)
     testImplementation(Libraries.CGLIB)
     testImplementation(Libraries.OBJENESIS)
+    testImplementation(Libraries.GROOVY)
 }
 
 // Add samples as inputs for testing

--- a/sample-check/src/main/java/org/gradle/samples/test/runner/GradleSamplesRunner.java
+++ b/sample-check/src/main/java/org/gradle/samples/test/runner/GradleSamplesRunner.java
@@ -61,12 +61,7 @@ public class GradleSamplesRunner extends SamplesRunner {
     }
 
     @Override
-    public CommandExecutionResult execute(final File tempSampleOutputDir, final Command command) {
-        File workingDir = tempSampleOutputDir;
-        if (command.getExecutionSubdirectory() != null) {
-            workingDir = new File(tempSampleOutputDir, command.getExecutionSubdirectory());
-        }
-
+    public CommandExecutionResult execute(File tempSampleOutputDir, File workingDir, Command command) {
         boolean expectFailure = command.isExpectFailure();
         ExecutionMetadata executionMetadata = getExecutionMetadata(tempSampleOutputDir);
         return new GradleRunnerCommandExecutor(workingDir, customGradleInstallation, expectFailure).execute(command, executionMetadata);

--- a/sample-check/src/test/groovy/org/gradle/samples/test/rule/SampleTest.groovy
+++ b/sample-check/src/test/groovy/org/gradle/samples/test/rule/SampleTest.groovy
@@ -15,7 +15,7 @@ class SampleTest {
     static class WithTemporaryFolderRule extends SampleTestCases {
 
         public TemporaryFolder temporaryFolder = new TemporaryFolder()
-        public Sample sample = Sample.from("src/test/samples/gradle")
+        Sample sample = Sample.from("src/test/samples/gradle")
             .into(temporaryFolder)
             .withDefaultSample("basic-sample")
 
@@ -27,6 +27,11 @@ class SampleTest {
         @Rule
         public Sample sample = Sample.from("src/test/samples/gradle")
             .withDefaultSample("basic-sample")
+
+        @Override
+        Sample getSample() {
+            return this.sample
+        }
     }
 
     static class WithExplicitTemporaryFolder extends SampleTestCases {
@@ -36,9 +41,16 @@ class SampleTest {
         public Sample sample = Sample.from("src/test/samples/gradle")
             .intoTemporaryFolder(temporaryFolder.getRoot())
             .withDefaultSample("basic-sample")
+
+        @Override
+        Sample getSample() {
+            return this.sample
+        }
     }
 
     static abstract class SampleTestCases {
+        abstract Sample getSample()
+
         @Test
         void "copies default sample"() {
             File sampleDir = sample.dir

--- a/sample-check/src/test/samples/cli/multi-step/multi-step.sample.conf
+++ b/sample-check/src/test/samples/cli/multi-step/multi-step.sample.conf
@@ -1,0 +1,11 @@
+commands: [{
+    executable = "mkdir"
+    args = "demo"
+}, {
+    executable = "cd"
+    args = "demo"
+}, {
+    executable = "bash"
+    args = "../sample.sh"
+    expected-output-file = "sample.out"
+}]

--- a/sample-check/src/test/samples/cli/multi-step/sample.out
+++ b/sample-check/src/test/samples/cli/multi-step/sample.out
@@ -1,0 +1,1 @@
+dir = demo

--- a/sample-check/src/test/samples/cli/multi-step/sample.sh
+++ b/sample-check/src/test/samples/cli/multi-step/sample.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "dir = `basename $PWD`"

--- a/sample-check/src/test/samples/gradle/build-init-sample/build-init.sample.conf
+++ b/sample-check/src/test/samples/gradle/build-init-sample/build-init.sample.conf
@@ -1,0 +1,19 @@
+commands = [
+    {
+        executable = "mkdir"
+        args = "demo"
+    },
+   {
+        executable = "cd"
+        args = "demo"
+   },
+   {
+        executable = "gradle"
+        args = "init"
+   },
+   {
+        executable = "gradle"
+        args = "projects"
+        expected-output-file = "sample.out"
+   }
+]

--- a/sample-check/src/test/samples/gradle/build-init-sample/sample.out
+++ b/sample-check/src/test/samples/gradle/build-init-sample/sample.out
@@ -1,0 +1,15 @@
+
+> Task :projects
+
+------------------------------------------------------------
+Root project
+------------------------------------------------------------
+
+Root project 'demo'
+No sub-projects
+
+To see a list of the tasks of a project, run gradle <project-path>:tasks
+For example, try running gradle :tasks
+
+BUILD SUCCESSFUL in 0s
+1 actionable task: 1 executed

--- a/sample-check/src/test/samples/gradle/multi-step-sample/build.gradle
+++ b/sample-check/src/test/samples/gradle/multi-step-sample/build.gradle
@@ -62,9 +62,11 @@ class IncrementalReverseTask extends DefaultTask {
 
         // START SNIPPET out-of-date-inputs
         inputs.outOfDate { change ->
-            println "out of date: ${change.file.name}"
-            def targetFile = new File(outputDir, change.file.name)
-            targetFile.text = change.file.text.reverse()
+            if (change.file.file) {
+                println "out of date: ${change.file.name}"
+                def targetFile = new File(outputDir, change.file.name)
+                targetFile.text = change.file.text.reverse()
+            }
         }
         // END SNIPPET out-of-date-inputs
 

--- a/sample-discovery/build.gradle.kts
+++ b/sample-discovery/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
     implementation(Libraries.COMMONS_LANG3)
     implementation(Libraries.TYPESAFE_CONFIG)
     testImplementation(Libraries.SPOCK_CORE)
+    testImplementation(Libraries.GROOVY)
 }

--- a/sample-discovery/src/main/java/org/gradle/samples/loader/asciidoctor/AsciidoctorSamplesDiscovery.java
+++ b/sample-discovery/src/main/java/org/gradle/samples/loader/asciidoctor/AsciidoctorSamplesDiscovery.java
@@ -142,7 +142,7 @@ public class AsciidoctorSamplesDiscovery {
             args = Arrays.asList(Arrays.copyOfRange(commandLineWords, 1, commandLineWords.length));
         }
 
-        String expectedOutput = null;
+        String expectedOutput = "";
         if (commandLineAndOutput.length > 1) {
             expectedOutput = commandLineAndOutput[1];
         }

--- a/sample-discovery/src/test/groovy/org/gradle/samples/loader/asciidoctor/AsciidoctorSamplesDiscoveryTest.groovy
+++ b/sample-discovery/src/test/groovy/org/gradle/samples/loader/asciidoctor/AsciidoctorSamplesDiscoveryTest.groovy
@@ -63,6 +63,7 @@ hello, world
         command.executable == "ruby"
         command.args == ["hello.rb"]
         command.allowDisorderedOutput
+        command.expectedOutput == "hello, world"
     }
 
     def "discovers samples inside an asciidoctor file with sources included"() {
@@ -108,5 +109,52 @@ Hello world
         def command = commands.get(0)
         command.executable == "bash"
         command.args == ["script.sh"]
+        command.expectedOutput == "Hello world"
+    }
+
+    def "discovers samples inside an asciidoctor file with multiple commands"() {
+        given:
+        def file = tmpDir.newFile("sample.adoc") << """
+= Document Title
+
+.Sample title
+====
+[.testable-sample]
+
+Run this first:
+
+[.sample-command]
+----
+\$ ruby hello.rb
+hello, world
+----
+
+Then do this:
+
+[.sample-command]
+----
+\$ mkdir some-dir
+----
+====
+"""
+
+        when:
+        Collection<Sample> samples = AsciidoctorSamplesDiscovery.extractFromAsciidoctorFile(file)
+
+        then:
+        samples.size() == 1
+        def commands = samples.get(0).commands
+
+        and:
+        commands.size() == 2
+        def command = commands.get(0)
+        command.executable == "ruby"
+        command.args == ["hello.rb"]
+        command.expectedOutput == "hello, world"
+
+        def command2 = commands.get(1)
+        command2.executable == "mkdir"
+        command2.args == ["some-dir"]
+        command2.expectedOutput.empty
     }
 }


### PR DESCRIPTION
Handle `cd <x>` commands, to keep track of the user's working directory and to apply this to subsequent commands for a multi-step sample. This allows, for example, something like:

```
$ mkdir demo
$ cd demo
$ gradle init
```