### PR TITLE
Allow multiple commands in a .sample-command Asciidoc block

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -24,9 +24,9 @@ This library is used to verify the functionality of samples in https://docs.grad
 First things first, you can pull this library down from Gradle's artifactory repository. This https://github.com/gradle/kotlin-dsl[Gradle Kotlin DSL] script shows one way to do just that.
 
 .Installing with Gradle
-====
 [.testable-sample]
-=====
+====
+
 .build.gradle.kts
 [source,kotlin]
 ----
@@ -48,9 +48,9 @@ dependencies {
 
 [.sample-command,allow-additional-output=true]
 ----
-$ gradle -q build
+$ gradle check
 ----
-=====
+
 ====
 
 == Usage
@@ -63,31 +63,18 @@ It may include link:https://asciidoctor.org/docs/user-manual/#include-partial[ta
 You can configure a sample to be tested by creating a file ending with `.sample.conf` (e.g. `hello-world.sample.conf`) in a sample project dir.
 This is a file in https://github.com/lightbend/config/blob/master/HOCON.md[HOCON format] that might look something like this:
 
-.sample-check/src/test/samples/cli/quickstart/quickstart.sample.conf
+.quickstart.sample.conf
 [source,hocon]
 ----
-executable: bash
-args: sample.sh
-expected-output-file: quickstart.sample.out
+include::../sample-check/src/test/samples/cli/quickstart/quickstart.sample.conf[]
 ----
 
 or maybe a more complex, multi-step sample:
 
-.sample-check/src/test/samples/gradle/multi-step-sample/incrementalTaskRemovedOutput.sample.conf
+.incrementalTaskRemovedOutput.sample.conf
 [source,hocon]
 ----
-commands: [{
-  executable: gradle
-  args: originalInputs incrementalReverse
-  expected-output-file: originalInputs.out
-  allow-additional-output: true
-}, {
-  executable: gradle
-  args: removeOutput incrementalReverse
-  flags: --quiet
-  expected-output-file: incrementalTaskRemovedOutput.out
-  allow-disordered-output: true
-}]
+include::../sample-check/src/test/samples/gradle/multi-step-sample/incrementalTaskRemovedOutput.sample.conf[]
 ----
 
 When there are multiple steps specified for a sample, they are run one after the other, in the order specified. The 'executable' can be either a command on the `$PATH`, or `gradle` (to run Gradle), or `cd` (to change the working directory for subsequent steps).
@@ -105,9 +92,9 @@ Use this syntax to allow sample-discovery to extract your sources from the doc, 
 [source,adoc]
 ----
 .Sample title
-====
 [.testable-sample]       // <1>
-=====
+====
+
 .hello.rb                // <2>
 [source,ruby]            // <3>
 -----
@@ -119,15 +106,15 @@ puts "hello, #{ARGV[0]}" // <4>
 $ ruby hello.rb world    // <6>
 hello, world             // <7>
 -----
-=====
+
 ====
 ----
 <1> Mark blocks containing your source files with the role `testable-sample`
 <2> The title of each source block should be the name of the source file
 <3> All source blocks with a title are extracted to a temporary directory
 <4> Source code. This can be `include::`d
-<5> Exemplar will execute the commands in a block with role `sample-command`
-<6> Terminal commands should start with "$ ". Everything afterward is executed
+<5> Exemplar will execute the commands in a block with role `sample-command`. There can be multiple blocks.
+<6> Terminal commands should start with "$ ". Everything after the "$ " is treated as a command to run. There can be multiple commands in a block.
 <7> One or more lines of expected output
 
 [NOTE] All sources have to be under the same block, and you must set the title of source blocks to a valid file name.

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -66,7 +66,9 @@ This is a file in https://github.com/lightbend/config/blob/master/HOCON.md[HOCON
 .quickstart.sample.conf
 [source,hocon]
 ----
-include::../sample-check/src/test/samples/cli/quickstart/quickstart.sample.conf[]
+executable: bash
+args: sample.sh
+expected-output-file: quickstart.sample.out
 ----
 
 or maybe a more complex, multi-step sample:
@@ -74,7 +76,18 @@ or maybe a more complex, multi-step sample:
 .incrementalTaskRemovedOutput.sample.conf
 [source,hocon]
 ----
-include::../sample-check/src/test/samples/gradle/multi-step-sample/incrementalTaskRemovedOutput.sample.conf[]
+commands: [{
+  executable: gradle
+  args: originalInputs incrementalReverse
+  expected-output-file: originalInputs.out
+  allow-additional-output: true
+}, {
+  executable: gradle
+  args: removeOutput incrementalReverse
+  flags: --quiet
+  expected-output-file: incrementalTaskRemovedOutput.out
+  allow-disordered-output: true
+}]
 ----
 
 When there are multiple steps specified for a sample, they are run one after the other, in the order specified. The 'executable' can be either a command on the `$PATH`, or `gradle` (to run Gradle), or `cd` (to change the working directory for subsequent steps).

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -256,10 +256,20 @@ For example, you might prepend a `Command` that sets up some environment before 
 
 To allow Gradle itself to run using test versions of Gradle, the `GradleSamplesRunner` allows a custom installation to be injected using the system property "integTest.gradleHomeDir".
 
-=== Contributing
+== Contributing
 
 [link=https://builds.gradle.org/viewType.html?buildTypeId=Build_Tool_Services_Exemplar]
 image::https://builds.gradle.org/guestAuth/app/rest/builds/buildType:(id:Build_Tool_Services_Exemplar)/statusIcon.svg[Build status]
 
 [link=https://gradle.org/conduct/]
 image::https://img.shields.io/badge/code%20of-conduct-lightgrey.svg?style=flat&colorB=ff69b4[code of conduct]
+
+== Changes
+
+=== Next release
+
+- Allow multiple commands to be defined in a `[.sample-command]` block.
+
+=== 0.8
+
+- Handle `cd <dir>` commands, to keep track of the user's working directory and apply it to later commands in the same sample.

--- a/sample-check/build.gradle.kts
+++ b/sample-check/build.gradle.kts
@@ -17,3 +17,9 @@ dependencies {
 
 // Add samples as inputs for testing
 sourceSets["test"].resources.srcDirs("src/test/samples")
+
+tasks.test {
+    useJUnit {
+        excludeCategories.add("org.gradle.samples.test.runner.CoveredByTests")
+    }
+}

--- a/sample-check/src/main/java/org/gradle/samples/executor/GradleRunnerCommandExecutor.java
+++ b/sample-check/src/main/java/org/gradle/samples/executor/GradleRunnerCommandExecutor.java
@@ -4,6 +4,7 @@ import org.apache.commons.io.IOUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -16,7 +17,7 @@ public class GradleRunnerCommandExecutor extends CommandExecutor {
     private final File customGradleInstallation;
     private final boolean expectFailure;
 
-    public GradleRunnerCommandExecutor(File workingDir, File customGradleInstallation, boolean expectFailure) {
+    public GradleRunnerCommandExecutor(File workingDir, @Nullable File customGradleInstallation, boolean expectFailure) {
         this.workingDir = workingDir;
         this.customGradleInstallation = customGradleInstallation;
         this.expectFailure = expectFailure;

--- a/sample-check/src/main/java/org/gradle/samples/executor/GradleRunnerCommandExecutor.java
+++ b/sample-check/src/main/java/org/gradle/samples/executor/GradleRunnerCommandExecutor.java
@@ -1,0 +1,56 @@
+package org.gradle.samples.executor;
+
+import org.apache.commons.io.IOUtils;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GradleRunnerCommandExecutor extends CommandExecutor {
+    private final File workingDir;
+    private final File customGradleInstallation;
+    private final boolean expectFailure;
+
+    public GradleRunnerCommandExecutor(File workingDir, File customGradleInstallation, boolean expectFailure) {
+        this.workingDir = workingDir;
+        this.customGradleInstallation = customGradleInstallation;
+        this.expectFailure = expectFailure;
+    }
+
+    @Override
+    protected int run(String executable, List<String> args, List<String> flags, OutputStream output) {
+        List<String> allArguments = new ArrayList<>(args);
+        allArguments.addAll(flags);
+
+        GradleRunner gradleRunner = GradleRunner.create()
+            .withProjectDir(workingDir)
+            .withArguments(allArguments)
+            .forwardOutput();
+
+        if (customGradleInstallation != null) {
+            gradleRunner.withGradleInstallation(customGradleInstallation);
+        }
+
+        Writer mergedOutput = new OutputStreamWriter(output);
+        try {
+            BuildResult buildResult;
+            if (expectFailure) {
+                buildResult = gradleRunner.buildAndFail();
+            } else {
+                buildResult = gradleRunner.build();
+            }
+            mergedOutput.write(buildResult.getOutput());
+            mergedOutput.close();
+            return expectFailure ? 1 : 0;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not execute " + executable, e);
+        } finally {
+            IOUtils.closeQuietly(mergedOutput);
+        }
+    }
+}

--- a/sample-check/src/main/java/org/gradle/samples/test/runner/GradleSamplesRunner.java
+++ b/sample-check/src/main/java/org/gradle/samples/test/runner/GradleSamplesRunner.java
@@ -76,6 +76,7 @@ public class GradleSamplesRunner extends SamplesRunner {
         }
     }
 
+    @Nullable
     private String getCustomGradleInstallationFromSystemProperty() {
         // Allow Gradle installation and samples root dir to be set from a system property
         // This is to allow Gradle to test Gradle installations during integration testing

--- a/sample-check/src/main/java/org/gradle/samples/test/runner/GradleSamplesRunner.java
+++ b/sample-check/src/main/java/org/gradle/samples/test/runner/GradleSamplesRunner.java
@@ -15,32 +15,25 @@
  */
 package org.gradle.samples.test.runner;
 
-import org.apache.commons.io.IOUtils;
 import org.gradle.api.JavaVersion;
 import org.gradle.samples.executor.CliCommandExecutor;
-import org.gradle.samples.executor.CommandExecutionResult;
 import org.gradle.samples.executor.CommandExecutor;
 import org.gradle.samples.executor.ExecutionMetadata;
+import org.gradle.samples.executor.GradleRunnerCommandExecutor;
 import org.gradle.samples.model.Command;
 import org.gradle.samples.model.Sample;
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runners.model.InitializationError;
 
+import javax.annotation.Nullable;
 import java.io.File;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A custom implementation of {@link SamplesRunner} that uses the Gradle Tooling API to execute sample builds.
  */
 public class GradleSamplesRunner extends SamplesRunner {
-    public static final String GRADLE_EXECUTABLE = "gradle";
+    private static final String GRADLE_EXECUTABLE = "gradle";
     @Rule
     public TemporaryFolder tempGradleUserHomeDir = new TemporaryFolder();
     private File customGradleInstallation = null;
@@ -61,37 +54,26 @@ public class GradleSamplesRunner extends SamplesRunner {
     }
 
     @Override
-    public CommandExecutionResult execute(File tempSampleOutputDir, File workingDir, Command command) {
+    protected CommandExecutor selectExecutor(ExecutionMetadata executionMetadata, File workingDir, Command command) {
         boolean expectFailure = command.isExpectFailure();
-        ExecutionMetadata executionMetadata = getExecutionMetadata(tempSampleOutputDir);
-        return new GradleRunnerCommandExecutor(workingDir, customGradleInstallation, expectFailure).execute(command, executionMetadata);
+        if (command.getExecutable().equals(GRADLE_EXECUTABLE)) {
+            return new GradleRunnerCommandExecutor(workingDir, customGradleInstallation, expectFailure);
+        }
+        return new CliCommandExecutor(workingDir);
     }
 
+    @Nullable
     @Override
-    protected File getSamplesRootDir() {
-        final String gradleHomeDir = getCustomGradleInstallationFromSystemProperty();
-        SamplesRoot samplesRoot = getTestClass().getAnnotation(SamplesRoot.class);
-        File samplesRootDir;
-        try {
-            if (samplesRoot != null) {
-                samplesRootDir = new File(samplesRoot.value());
-            } else if (System.getProperty("integTest.samplesdir") != null) {
-                String samplesRootProperty = System.getProperty("integTest.samplesdir", gradleHomeDir + "/samples");
-                samplesRootDir = new File(samplesRootProperty);
-            } else if (customGradleInstallation != null) {
-                samplesRootDir = new File(customGradleInstallation, "samples");
-            } else {
-                throw new InitializationError("Samples root directory is not declared. Please annotate your test class with @SamplesRoot(\"path/to/samples\")");
-            }
-
-            if (!samplesRootDir.exists()) {
-                throw new InitializationError("Samples root directory " + samplesRootDir.getAbsolutePath() + " does not exist");
-            }
-        } catch (InitializationError e) {
-            throw new RuntimeException("Could not initialize GradleSamplesRunner", e);
+    protected File getImplicitSamplesRootDir() {
+        String gradleHomeDir = getCustomGradleInstallationFromSystemProperty();
+        if (System.getProperty("integTest.samplesdir") != null) {
+            String samplesRootProperty = System.getProperty("integTest.samplesdir", gradleHomeDir + "/samples");
+            return new File(samplesRootProperty);
+        } else if (customGradleInstallation != null) {
+            return new File(customGradleInstallation, "samples");
+        } else {
+            return null;
         }
-
-        return samplesRootDir;
     }
 
     private String getCustomGradleInstallationFromSystemProperty() {
@@ -109,51 +91,4 @@ public class GradleSamplesRunner extends SamplesRunner {
         return gradleHomeDirProperty;
     }
 
-    private static class GradleRunnerCommandExecutor extends CommandExecutor {
-        private final File workingDir;
-        private final File customGradleInstallation;
-        private final boolean expectFailure;
-
-        private GradleRunnerCommandExecutor(File workingDir, File customGradleInstallation, boolean expectFailure) {
-            this.workingDir = workingDir;
-            this.customGradleInstallation = customGradleInstallation;
-            this.expectFailure = expectFailure;
-        }
-
-        @Override
-        protected int run(String executable, List<String> args, List<String> flags, OutputStream output) {
-            if (!executable.equals(GRADLE_EXECUTABLE)) {
-                return new CliCommandExecutor(workingDir).run(executable, args, flags, output);
-            }
-
-            List<String> allArguments = new ArrayList<>(args);
-            allArguments.addAll(flags);
-
-            GradleRunner gradleRunner = GradleRunner.create()
-                    .withProjectDir(workingDir)
-                    .withArguments(allArguments)
-                    .forwardOutput();
-
-            if (customGradleInstallation != null) {
-                gradleRunner.withGradleInstallation(customGradleInstallation);
-            }
-
-            Writer mergedOutput = new OutputStreamWriter(output);
-            try {
-                BuildResult buildResult;
-                if (expectFailure) {
-                    buildResult = gradleRunner.buildAndFail();
-                } else {
-                    buildResult = gradleRunner.build();
-                }
-                mergedOutput.write(buildResult.getOutput());
-                mergedOutput.close();
-                return expectFailure ? 1 : 0;
-            } catch (Exception e) {
-                throw new RuntimeException("Could not execute " + executable, e);
-            } finally {
-                IOUtils.closeQuietly(mergedOutput);
-            }
-        }
-    }
 }

--- a/sample-check/src/main/java/org/gradle/samples/test/runner/SamplesRunner.java
+++ b/sample-check/src/main/java/org/gradle/samples/test/runner/SamplesRunner.java
@@ -41,6 +41,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
+/**
+ * A JUnit test runner that verifies all samples discovered in the directory specified by the {@link SamplesRoot} annotation.
+ */
 public class SamplesRunner extends ParentRunner<Sample> {
     // See https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html
     public static final List<String> SAFE_SYSTEM_PROPERTIES = Arrays.asList("file.separator", "java.home", "java.vendor", "java.version", "line.separator", "os.arch", "os.name", "os.version", "path.separator", "user.dir", "user.home", "user.name");
@@ -107,13 +110,13 @@ public class SamplesRunner extends ParentRunner<Sample> {
             if (samplesRoot != null) {
                 samplesRootDir = new File(samplesRoot.value());
             } else {
-                throw new InitializationError("Samples root directory is not declared. Please annotate your test class with @SamplesRoot(\"path/to/samples\")");
+                throw new IllegalArgumentException("Samples root directory is not declared. Please annotate your test class with @SamplesRoot(\"path/to/samples\")");
             }
 
             if (!samplesRootDir.exists()) {
-                throw new InitializationError("Samples root directory " + samplesRootDir.getAbsolutePath() + " does not exist");
+                throw new IllegalArgumentException("Samples root directory " + samplesRootDir.getAbsolutePath() + " does not exist");
             }
-        } catch (InitializationError e) {
+        } catch (Exception e) {
             throw new RuntimeException("Could not initialize SamplesRunner", e);
         }
         return samplesRootDir;

--- a/sample-check/src/test/docs/embedded-test.adoc
+++ b/sample-check/src/test/docs/embedded-test.adoc
@@ -6,10 +6,10 @@ This doc demonstrates how one can declare embedded commands instead of using `.s
 
 Here we see sources that are `include`d, and inline commands and output.
 
+[.testable-sample,dir="src/test/samples/cli/quickstart"]
 .CLI quickstart sample
 ====
-[.testable-sample,dir="src/test/samples/cli/quickstart"]
-=====
+
 .sample.sh
 [source,bash]
 ----
@@ -21,17 +21,17 @@ include::src/test/samples/cli/quickstart/sample.sh[]
 $ bash sample.sh
 hello, world
 ----
-=====
+
 ====
 
 == Embedded sources and commands example
 
 This example embeds all the things.
 
+[.testable-sample]
 .Gradle custom logging example
 ====
-[.testable-sample]
-=====
+
 .build.gradle
 [source,groovy]
 ----
@@ -102,5 +102,36 @@ running unit tests
 build completed
 3 actionable tasks: 3 executed
 ----
-=====
+
+====
+
+== Multi-step sample
+
+[.testable-sample]
+====
+
+.sample.sh
+[source]
+----
+#!/usr/bin/env bash
+
+echo "dir = `basename $PWD`"
+----
+
+Create a directory:
+
+[.sample-command]
+----
+$ mkdir demo
+$ cd demo
+----
+
+Run the script:
+
+[.sample-command]
+----
+$ bash ../sample.sh
+dir = demo
+----
+
 ====

--- a/sample-check/src/test/groovy/org/gradle/samples/test/runner/CollectingNotifier.groovy
+++ b/sample-check/src/test/groovy/org/gradle/samples/test/runner/CollectingNotifier.groovy
@@ -1,0 +1,22 @@
+package org.gradle.samples.test.runner
+
+import org.junit.runner.Description
+import org.junit.runner.notification.Failure
+import org.junit.runner.notification.RunNotifier
+import org.junit.runner.notification.StoppedByUserException
+
+
+class CollectingNotifier extends RunNotifier {
+    final List<Description> tests = []
+    final List<Failure> failures = []
+
+    @Override
+    void fireTestStarted(Description description) throws StoppedByUserException {
+        tests.add(description)
+    }
+
+    @Override
+    void fireTestFailure(Failure failure) {
+        failures.add(failure)
+    }
+}

--- a/sample-check/src/test/groovy/org/gradle/samples/test/runner/SamplesRunnerIntegrationTest.groovy
+++ b/sample-check/src/test/groovy/org/gradle/samples/test/runner/SamplesRunnerIntegrationTest.groovy
@@ -1,0 +1,32 @@
+package org.gradle.samples.test.runner
+
+import org.junit.experimental.categories.Category
+import org.junit.runner.Request
+import org.junit.runner.RunWith
+import spock.lang.Specification
+
+
+class SamplesRunnerIntegrationTest extends Specification {
+    def "runs samples-check CLI samples"() {
+        def notifier = new CollectingNotifier()
+
+        when:
+        Request.aClass(HappyDaySamples.class).runner.run(notifier)
+
+        then:
+        notifier.tests.size() == 2
+        notifier.tests[0].methodName == 'multi-step_multi-step.sample'
+        notifier.tests[0].className == HappyDaySamples.class.name
+
+        notifier.tests[1].methodName == 'quickstart_quickstart.sample'
+        notifier.tests[1].className == HappyDaySamples.class.name
+
+        notifier.failures.empty
+    }
+
+    @RunWith(SamplesRunner.class)
+    @SamplesRoot("src/test/samples/cli")
+    @Category(CoveredByTests)
+    static class HappyDaySamples {
+    }
+}

--- a/sample-check/src/test/groovy/org/gradle/samples/test/runner/SamplesRunnerSadDayIntegrationTest.groovy
+++ b/sample-check/src/test/groovy/org/gradle/samples/test/runner/SamplesRunnerSadDayIntegrationTest.groovy
@@ -1,0 +1,73 @@
+package org.gradle.samples.test.runner
+
+import org.junit.Rule
+import org.junit.experimental.categories.Category
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.Request
+import org.junit.runner.RunWith
+import org.junit.runner.notification.Failure
+import org.junit.runner.notification.RunNotifier
+import spock.lang.Specification
+
+class SamplesRunnerSadDayIntegrationTest extends Specification {
+    @Rule
+    TemporaryFolder tmpDir = new TemporaryFolder()
+
+    def "tests fail when command fails"() {
+        def notifier = new CollectingNotifier()
+
+        when:
+        Request.aClass(HasBadCommand.class).runner.run(notifier)
+
+        then:
+        notifier.failures.size() == 1
+        notifier.failures[0].description.methodName == '_broken-command.sample'
+        notifier.failures[0].description.className == HasBadCommand.class.name
+        notifier.failures[0].message.trim() == """
+            Expected sample invocation to succeed but it failed.
+            Command was: 'bash broken'
+            [BEGIN OUTPUT]
+            bash: broken: No such file or directory
+            
+            [END OUTPUT]
+        """.stripIndent().trim()
+    }
+
+    def "tests fail when command produces unexpected output"() {
+        def notifier = new CollectingNotifier()
+
+        when:
+        Request.aClass(HasBadOutput.class).runner.run(notifier)
+
+        then:
+        notifier.failures.size() == 1
+        notifier.failures[0].description.methodName == '_broken-output.sample'
+        notifier.failures[0].description.className == HasBadOutput.class.name
+        notifier.failures[0].message.trim() == """
+            Missing text at line 1.
+            Expected: not a thing
+            Actual: thing
+            Actual output:
+            thing
+        """.stripIndent().trim()
+    }
+
+    @SamplesRoot("src/test/resources/broken/command")
+    @RunWith(SamplesRunner)
+    @Category(CoveredByTests)
+    static class HasBadCommand {}
+
+    @SamplesRoot("src/test/resources/broken/output")
+    @RunWith(SamplesRunner)
+    @Category(CoveredByTests)
+    static class HasBadOutput {}
+
+    static class CollectingNotifier extends RunNotifier {
+        final List<Failure> failures = []
+
+        @Override
+        void fireTestFailure(Failure failure) {
+            failures.add(failure)
+        }
+    }
+}

--- a/sample-check/src/test/groovy/org/gradle/samples/test/runner/SamplesRunnerSadDayIntegrationTest.groovy
+++ b/sample-check/src/test/groovy/org/gradle/samples/test/runner/SamplesRunnerSadDayIntegrationTest.groovy
@@ -5,8 +5,6 @@ import org.junit.experimental.categories.Category
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.Request
 import org.junit.runner.RunWith
-import org.junit.runner.notification.Failure
-import org.junit.runner.notification.RunNotifier
 import spock.lang.Specification
 
 class SamplesRunnerSadDayIntegrationTest extends Specification {
@@ -20,9 +18,12 @@ class SamplesRunnerSadDayIntegrationTest extends Specification {
         Request.aClass(HasBadCommand.class).runner.run(notifier)
 
         then:
+        notifier.tests.size() == 1
+        notifier.tests[0].methodName == '_broken-command.sample'
+        notifier.tests[0].className == HasBadCommand.class.name
+
         notifier.failures.size() == 1
-        notifier.failures[0].description.methodName == '_broken-command.sample'
-        notifier.failures[0].description.className == HasBadCommand.class.name
+        notifier.failures[0].description == notifier.tests[0]
         notifier.failures[0].message.trim() == """
             Expected sample invocation to succeed but it failed.
             Command was: 'bash broken'
@@ -40,9 +41,12 @@ class SamplesRunnerSadDayIntegrationTest extends Specification {
         Request.aClass(HasBadOutput.class).runner.run(notifier)
 
         then:
+        notifier.tests.size() == 1
+        notifier.tests[0].methodName == '_broken-output.sample'
+        notifier.tests[0].className == HasBadOutput.class.name
+
         notifier.failures.size() == 1
-        notifier.failures[0].description.methodName == '_broken-output.sample'
-        notifier.failures[0].description.className == HasBadOutput.class.name
+        notifier.failures[0].description == notifier.tests[0]
         notifier.failures[0].message.trim() == """
             Missing text at line 1.
             Expected: not a thing
@@ -61,13 +65,4 @@ class SamplesRunnerSadDayIntegrationTest extends Specification {
     @RunWith(SamplesRunner)
     @Category(CoveredByTests)
     static class HasBadOutput {}
-
-    static class CollectingNotifier extends RunNotifier {
-        final List<Failure> failures = []
-
-        @Override
-        void fireTestFailure(Failure failure) {
-            failures.add(failure)
-        }
-    }
 }

--- a/sample-check/src/test/java/org/gradle/samples/test/normalizer/GradleOutputNormalizer.java
+++ b/sample-check/src/test/java/org/gradle/samples/test/normalizer/GradleOutputNormalizer.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 public class GradleOutputNormalizer implements OutputNormalizer {
-    private static final String NORMALIZED_SAMPLES_PATH = "/home/user/gradle/samples";
     private static final Pattern STACK_TRACE_ELEMENT = Pattern.compile("\\s+(at\\s+)?([\\w.$_]+/)?[\\w.$_]+\\.[\\w$_ =+\'-<>]+\\(.+?\\)(\\x1B\\[0K)?");
     private static final Pattern BUILD_RESULT_PATTERN = Pattern.compile("BUILD (SUCCESSFUL|FAILED) in( \\d+[smh])+");
 

--- a/sample-check/src/test/java/org/gradle/samples/test/runner/CoveredByTests.java
+++ b/sample-check/src/test/java/org/gradle/samples/test/runner/CoveredByTests.java
@@ -1,0 +1,7 @@
+package org.gradle.samples.test.runner;
+
+/**
+ * Indicates test classes that are exercised by some other test (eg broken tests).
+ */
+public interface CoveredByTests {
+}

--- a/sample-check/src/test/resources/broken/command/broken-command.sample.conf
+++ b/sample-check/src/test/resources/broken/command/broken-command.sample.conf
@@ -1,0 +1,2 @@
+executable = bash
+args = broken

--- a/sample-check/src/test/resources/broken/output/broken-output.sample.conf
+++ b/sample-check/src/test/resources/broken/output/broken-output.sample.conf
@@ -1,0 +1,3 @@
+executable = echo
+args = thing
+expected-output-file: sample.out

--- a/sample-check/src/test/resources/broken/output/sample.out
+++ b/sample-check/src/test/resources/broken/output/sample.out
@@ -1,0 +1,1 @@
+not a thing


### PR DESCRIPTION
This PR adds support for multiple command in a `[.sample-command]` block. For example:

```
[source,.sample-command]
$ mkdir demp
$ cd demo
```

There's also some refactoring to reduce duplication and add some test coverage, in particular to verify that tests fail when a sample command fails or produces unexpected output.