### PR TITLE
Publish build scans to ge.gradle.org

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
-    id("com.gradle.enterprise").version("3.4.1")
+    id("com.gradle.enterprise").version("3.6.1")
+    id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
 }
 
 rootProject.name = "exemplar"
@@ -7,14 +8,3 @@ rootProject.name = "exemplar"
 include("sample-discovery")
 include("sample-check")
 include("docs")
-
-gradleEnterprise {
-    buildScan {
-        setTermsOfServiceUrl("https://gradle.com/terms-of-service")
-        setTermsOfServiceAgree("yes")
-        if (!System.getenv("CI").isNullOrEmpty()) {
-            publishAlways()
-            tag("CI")
-        }
-    }
-}


### PR DESCRIPTION
Instead of publishing to scans.gradle.com we now apply the
gradle-enterprise-conventions-plugin which configured ge.gradle.org as
the Gradle Enterprise instance and also adds some useful tags and custom
values.