### PR TITLE
Update commons-io to latest version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ spock = "2.0-groovy-3.0"
 
 [libraries]
 asciidoctorj = "org.asciidoctor:asciidoctorj:1.5.8.1"
-commons-io = "commons-io:commons-io:2.11.0"
+commons-io = "commons-io:commons-io:2.18.0"
 commons-lang3 = "org.apache.commons:commons-lang3:3.12.0"
 groovy = "org.codehaus.groovy:groovy:3.0.8"
 junit = "junit:junit:4.13.2"


### PR DESCRIPTION
We're seeing dependabot alerts reported against GradleX plugins because of a transitive dependency to commons-io 2.11.0. In particular we're seeing https://github.com/advisories/GHSA-78wr-2p64-hpwj and https://github.com/advisories/GHSA-gwrp-pvrq-jmwv.

This PR updates the dependency to commons-io to the latest version.