### PR TITLE
Fail the test if exceptions are thrown during sample discovery

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "org.gradle.exemplar"
-version = "1.1.0-SNAPSHOT"
+version = "1.0.3"
 
 nexusPublishing {
     repositories.apply {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,16 @@
 [versions]
 spock = "2.0-groovy-3.0"
+junit-vintage = "5.12.2"
+junit-launcher = "1.12.2"
 
 [libraries]
 asciidoctorj = "org.asciidoctor:asciidoctorj:1.5.8.1"
-commons-io = "commons-io:commons-io:2.11.0"
+commons-io = "commons-io:commons-io:2.18.0"
 commons-lang3 = "org.apache.commons:commons-lang3:3.12.0"
 groovy = "org.codehaus.groovy:groovy:3.0.8"
-junit = "junit:junit:4.13.2"
-junit-vintage-engine = "org.junit.vintage:junit-vintage-engine:5.8.1"
+junit4 = "junit:junit:4.13.2"
+junit-vintage = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit-vintage" }
+junit-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-launcher" }
 jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 objenesis = "org.objenesis:objenesis:3.2"
 spock-core = { module="org.spockframework:spock-core", version.ref="spock" }

--- a/samples-check/build.gradle.kts
+++ b/samples-check/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     api(project(":samples-discovery"))
-    api(libs.junit)
+    api(libs.junit4)
     compileOnly(libs.jsr305)
     implementation(libs.commons.io)
     implementation(libs.commons.lang3)
@@ -13,7 +13,8 @@ dependencies {
     testImplementation(libs.groovy)
     testImplementation(libs.objenesis)
     testImplementation(libs.bundles.spock)
-    testRuntimeOnly(libs.junit.vintage.engine)
+    testRuntimeOnly(libs.junit.vintage)
+    testRuntimeOnly(libs.junit.launcher)
 }
 
 tasks.test {

--- a/samples-check/src/main/java/org/gradle/exemplar/test/runner/SamplesRunner.java
+++ b/samples-check/src/main/java/org/gradle/exemplar/test/runner/SamplesRunner.java
@@ -23,6 +23,7 @@ import org.gradle.exemplar.executor.CommandExecutor;
 import org.gradle.exemplar.executor.ExecutionMetadata;
 import org.gradle.exemplar.loader.SamplesDiscovery;
 import org.gradle.exemplar.model.Command;
+import org.gradle.exemplar.model.InvalidSample;
 import org.gradle.exemplar.model.Sample;
 import org.gradle.exemplar.test.normalizer.OutputNormalizer;
 import org.gradle.exemplar.test.verifier.AnyOrderLineSegmentedOutputVerifier;
@@ -142,7 +143,9 @@ public class SamplesRunner extends ParentRunner<Sample> {
     @Override
     protected void runChild(final Sample sample, final RunNotifier notifier) {
         Description childDescription = describeChild(sample);
-        if (isIgnored(sample)) {
+        if (sample instanceof InvalidSample) {
+            notifier.fireTestFailure(new Failure(childDescription, ((InvalidSample) sample).getException()));
+        } else if (isIgnored(sample)) {
             notifier.fireTestIgnored(childDescription);
         } else {
             notifier.fireTestStarted(childDescription);

--- a/samples-check/src/test/groovy/org/gradle/exemplar/test/runner/BrokenSampleDiscoveryIntegrationTest.groovy
+++ b/samples-check/src/test/groovy/org/gradle/exemplar/test/runner/BrokenSampleDiscoveryIntegrationTest.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.exemplar.test.runner
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import org.junit.platform.engine.discovery.DiscoverySelectors
+import org.junit.platform.launcher.Launcher
+import org.junit.platform.launcher.LauncherDiscoveryRequest
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder
+import org.junit.platform.launcher.core.LauncherFactory
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener
+import spock.lang.Specification
+
+class BrokenSampleDiscoveryIntegrationTest extends Specification {
+    @Rule
+    TemporaryFolder tmpDir = new TemporaryFolder()
+
+    def "start JUnit vintage engine via launcher"() {
+        given:
+        def brokenSample = tmpDir.newFile("broken.sample.conf")
+        brokenSample << """
+            executable: sleep
+            args: 1
+            expected-output-file: not-exist.sample.out
+        """.stripMargin()
+
+        def testClass = """
+            package org.gradle.exemplar.test;
+            
+            import org.gradle.exemplar.test.runner.SamplesRunner;
+            import org.gradle.exemplar.test.runner.SamplesRoot;
+            import org.junit.runner.RunWith;
+
+            @RunWith(SamplesRunner.class)
+            @SamplesRoot("${tmpDir.root.absolutePath}")
+            public class SimpleJUnit4Test {
+            }
+        """
+
+        def testClassFile = tmpDir.newFile("SimpleJUnit4Test.java")
+        testClassFile.text = testClass
+
+        def compiler = new GroovyClassLoader()
+        def compiledClass = compiler.parseClass(testClassFile)
+
+        when:
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(DiscoverySelectors.selectClass(compiledClass))
+                .build()
+
+        Launcher launcher = LauncherFactory.create()
+        def listener = new SummaryGeneratingListener()
+        launcher.registerTestExecutionListeners(listener)
+
+        launcher.execute(request)
+
+        then:
+        listener.summary.testsFailedCount == 1
+        listener.summary.failures[0].exception.message.contains("Could not read sample definition")
+    }
+}

--- a/samples-discovery/src/main/java/org/gradle/exemplar/loader/SamplesDiscovery.java
+++ b/samples-discovery/src/main/java/org/gradle/exemplar/loader/SamplesDiscovery.java
@@ -19,6 +19,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.gradle.exemplar.loader.asciidoctor.AsciidoctorSamplesDiscovery;
 import org.gradle.exemplar.model.Command;
+import org.gradle.exemplar.model.InvalidSample;
 import org.gradle.exemplar.model.Sample;
 
 import java.io.File;
@@ -37,11 +38,15 @@ public class SamplesDiscovery {
         List<Sample> samples = new ArrayList<>();
         for (File sampleConfigFile : sampleConfigFiles) {
             final String id = generateSampleId(rootSamplesDir, sampleConfigFile);
-            final List<Command> commands = CommandsParser.parse(sampleConfigFile);
-            // FIXME: Currently the temp directory used when running samples-check has a different name.
-            // This causes Gradle project names to differ when one is not explicitly set in settings.gradle. This should be preserved.
-            final File sampleProjectDir = sampleConfigFile.getParentFile();
-            samples.add(new Sample(id, sampleProjectDir, commands));
+            try {
+                final List<Command> commands = CommandsParser.parse(sampleConfigFile);
+                // FIXME: Currently the temp directory used when running samples-check has a different name.
+                // This causes Gradle project names to differ when one is not explicitly set in settings.gradle. This should be preserved.
+                final File sampleProjectDir = sampleConfigFile.getParentFile();
+                samples.add(new Sample(id, sampleProjectDir, commands));
+            } catch (Exception e) {
+                samples.add(new InvalidSample(id, e));
+            }
         }
         // Always return (and test) samples in a fixed order
         sortSamples(samples);

--- a/samples-discovery/src/main/java/org/gradle/exemplar/model/InvalidSample.java
+++ b/samples-discovery/src/main/java/org/gradle/exemplar/model/InvalidSample.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.exemplar.model;
+
+import java.util.Collections;
+
+public class InvalidSample extends Sample {
+    private final Exception exception;
+
+    public InvalidSample(String id, Exception exception) {
+        super(id, null, Collections.emptyList());
+        this.exception = exception;
+    }
+
+    public Exception getException() {
+        return exception;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/33075

In the past, if an exception is thrown in sample discovery  (e.g. the expected output file doesn't exist), JUnit Vintage Engine will silently ignore all tests in the runner (see the test case in `BrokenSampleDiscoveryIntegrationTest`).

This PR introduces an `InvalidSample` class to capture the exception thrown, then notify the corresponding test notifier during execution. In this way, other good samples are still able to be run.