### PR TITLE
Fix Maven Central publication: migrate to Central Portal staging API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,8 +12,8 @@ tasks.named<UpdateDaemonJvm>("updateDaemonJvm").configure {
 nexusPublishing {
     repositories.apply {
         sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username.set(System.getenv("MAVEN_CENTRAL_STAGING_REPO_USER"))
             password.set(System.getenv("MAVEN_CENTRAL_STAGING_REPO_PASSWORD"))
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,6 @@
 [versions]
 asciidoctorj = "3.0.1"
-junit-launcher = "6.1.0"
-junit-platform-engine = "6.1.0"
-junit-vintage = "6.1.0"
+junit = "6.1.0"
 spock = "2.4-groovy-4.0"
 
 [libraries]
@@ -12,9 +10,9 @@ commons-io = "commons-io:commons-io:2.22.0"
 commons-lang3 = "org.apache.commons:commons-lang3:3.20.0"
 groovy = "org.apache.groovy:groovy:4.0.29"
 jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
-junit-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-launcher" }
-junit-platform-engine = { module = "org.junit.platform:junit-platform-engine", version.ref = "junit-platform-engine" }
-junit-vintage = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit-vintage" }
+junit-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
+junit-platform-engine = { module = "org.junit.platform:junit-platform-engine", version.ref = "junit" }
+junit-vintage = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit" }
 junit4 = "junit:junit:4.13.2"
 spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }
 spock-junit4 = { module = "org.spockframework:spock-junit4", version.ref = "spock" }


### PR DESCRIPTION
- OSSRH (`s01.oss.sonatype.org`) was retired on 2025-06-30, so the "Publish Exemplar" TeamCity job now fails with HTTP 402.
- Point `gradle-nexus-publish-plugin` at Sonatype's Nexus 2-compatible Central Portal shim (`ossrh-staging-api.central.sonatype.com`) — same approach already in use by [gradle/gradle-profiler](https://github.com/gradle/gradle-profiler/blob/master/build.gradle.kts).
