### PR TITLE
Auto close and release Sonatype staging repository

### DIFF
--- a/.teamcity/Project.kt
+++ b/.teamcity/Project.kt
@@ -96,7 +96,7 @@ object Publish : BuildType({
     steps {
         gradle {
             useGradleWrapper = true
-            tasks = "clean publishMavenJavaPublicationToSonatypeRepository"
+            tasks = "clean publishToSonatype closeAndReleaseSonatypeStagingRepository"
             gradleParams = "-Dgradle.publish.skip.namespace.check=true"
         }
     }


### PR DESCRIPTION
## Summary
- Previous setup only ran \`publishMavenJavaPublicationToSonatypeRepository\`, which uploads artifacts to an open staging repo but never closes or releases it. Through the new Central Publisher Portal compatibility shim, that deployment never surfaces in the Portal UI, so artifacts never reach Maven Central.
- Replace with \`publishToSonatype closeAndReleaseSonatypeStagingRepository\` so the build drives upload → close (validation) → release (publish to Central) end-to-end.
- Same task list used by [gradle/gradle-profiler](https://github.com/gradle/gradle-profiler/blob/master/.teamcity/src/main/kotlin/GradleProfilerPublishing.kt).

## Test plan
- [ ] Trigger \`Publish Exemplar\` against a throwaway version.
- [ ] Watch the build run \`initialize\` → \`publish\` → \`close\` → \`release\` Sonatype staging tasks.
- [ ] Confirm artifacts appear at https://repo.maven.apache.org/maven2/org/gradle/exemplar/ within ~30 min, with no manual click required in the Central Portal UI.